### PR TITLE
Updating QuickNode name.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,8 +31,8 @@ In the below sections you can find a list of different layers of the BSC Stack.
 ### :factory: Infrastructure
 | Components | Existing projects | Potentially interesting projects
 |-|-|-
-|API/Node access| [Ankr](https://www.ankr.com/), [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [NowNodes](https://nownodes.io/blog/binance-smart-chain-an-introduction), [QuikNode](https://www.quiknode.io/)
-|Archive Node Service| [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [InfStones](https://infstones.com/)
+|API/Node access| [Ankr](https://www.ankr.com/), [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [NowNodes](https://nownodes.io/blog/binance-smart-chain-an-introduction), [QuickNode](https://www.quicknode.com/)
+|Archive Node Service| [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [InfStones](https://infstones.com/), [QuickNode](https://www.quicknode.com/)
 |Public RPC Endpoints| [RPC Endpoints](https://docs.binance.org/smart-chain/developer/rpc.html)| More public nodes are encouraged
 |Community Polling Dashboard| [snapshot](https://snapshot.page/)
 |Gas Station Network| [opengsn](https://opengsn.org/)


### PR DESCRIPTION
Updated old [QuikNode](https://quiknode.io) to [QuickNode](https://quicknode.com) with a `c` and new website link.
Also, added QuickNode under Archive nodes as it provides BSC Full Archive nodes.